### PR TITLE
[FIX] purchase_delivery_split_date: Split improvements

### DIFF
--- a/purchase_delivery_split_date/__manifest__.py
+++ b/purchase_delivery_split_date/__manifest__.py
@@ -1,5 +1,6 @@
 # Copyright 2014-2016 Numérigraphe SARL
 # Copyright 2017 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
@@ -7,11 +8,13 @@
     "version": "16.0.1.0.0",
     "summary": "Allows Purchase Order you confirm to generate one Incoming "
     "Shipment for each expected date indicated in the Purchase Order Lines",
-    "author": "Numerigraphe, ForgeFlow, Camptocamp, Odoo Community Association (OCA)",
+    "author": (
+        "Numerigraphe, ForgeFlow, Camptocamp, BCIM, Odoo Community Association (OCA)"
+    ),
     "website": "https://github.com/OCA/purchase-workflow",
     "category": "Purchase Management",
     "license": "AGPL-3",
-    "depends": ["purchase_stock", "base_partition"],
+    "depends": ["purchase_stock"],
     "installable": True,
     "application": False,
 }

--- a/purchase_delivery_split_date/models/purchase_order_line.py
+++ b/purchase_delivery_split_date/models/purchase_order_line.py
@@ -1,97 +1,85 @@
 # Copyright 2014-2016 Numérigraphe SARL
 # Copyright 2017 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from itertools import groupby
 
-from odoo import api, fields, models
+import pytz
+
+from odoo import fields, models
 
 
 class PurchaseOrderLine(models.Model):
 
     _inherit = "purchase.order.line"
 
-    @api.model
-    def _get_group_keys(self, order, line, picking=False):
-        """Define the key that will be used to group. The key should be
-        defined as a tuple of dictionaries, with each element containing a
-        dictionary element with the field that you want to group by. This
-        method is designed for extensibility, so that other modules can add
-        additional keys or replace them by others."""
-        date = fields.Date.context_today(self.env.user, line.date_planned)
+    def _purchase_split_date_get_group_keys(self, picking):
+        """Define the key that will be used to group.
+
+        The key should be defined as a tuple of dictionaries, with each element
+        containing a dictionary element with the field that you want to group
+        by. This method is designed for extensibility, so that other modules
+        can add additional keys or replace them by others.
+        """
+        tz = self.order_id.picking_type_id.warehouse_id.partner_id.tz
+        wh_tz = pytz.timezone(tz or self.env.user.tz or "UTC")
+        date_planned_tz = self.date_planned.astimezone(pytz.utc).astimezone(wh_tz)
+        date = date_planned_tz.date()
         # Split date value to obtain only the attributes year, month and day
         key = ({"date_planned": fields.Date.to_string(date)},)
         return key
 
-    def _get_split_move_by_date_group(self):
-        return lambda line: fields.Date.context_today(self.env.user, line.date_planned)
-
-    @api.model
-    def _first_picking_copy_vals(self, key, lines):
-        """The data to be copied to new pickings is updated with data from the
-        grouping key.  This method is designed for extensibility, so that
-        other modules can store more data based on new keys."""
-        vals = {"move_ids": []}
-        for key_element in key:
-            if "date_planned" in key_element.keys():
-                vals["scheduled_date"] = key_element["date_planned"]
-        return vals
-
-    def _get_sorted_keys(self, line):
+    def _purchase_split_date_get_sorted_keys(self):
         """Return a tuple of keys to use in order to sort the order lines.
+
         This method is designed for extensibility, so that other modules can
-        add additional keys or replace them by others."""
-        return (line.date_planned,)
+        add additional keys or replace them by others.
+        """
+        return (self.date_planned,)
 
     def _create_stock_moves(self, picking):
-        """Group the receptions in one picking per group key"""
+        """Group the receptions in one picking per assignation domain"""
+        if not picking:
+            # A picking should be provided
+            return super()._create_stock_moves(picking)
         moves = self.env["stock.move"]
+        tz = picking.picking_type_id.warehouse_id.partner_id.tz or self.env.user.tz
         # Group the order lines by group key
         order_lines = sorted(
-            self.filtered(lambda l: not l.display_type),
-            key=lambda l: self._get_sorted_keys(l),
+            self.filtered(
+                lambda line: not line.display_type
+                and line.product_id.type in ["product", "consu"]
+            ),
+            key=lambda line: line._purchase_split_date_get_sorted_keys(),
         )
         date_groups = groupby(
-            order_lines, lambda l: self._get_group_keys(l.order_id, l, picking=picking)
+            order_lines,
+            lambda line: line._purchase_split_date_get_group_keys(picking),
         )
 
-        first_picking = False
-        # If a picking is provided, use it for the first group only
-        if picking:
-            first_picking = picking
-            key, lines = next(date_groups)
-            po_lines = self.env["purchase.order.line"]
-            for line in list(lines):
-                po_lines += line
-            picking._update_picking_from_group_key(key)
-            moves += super(PurchaseOrderLine, po_lines)._create_stock_moves(
-                first_picking
-            )
-
         for key, lines in date_groups:
-            # If a picking is provided, clone it for each key for modularity
-            if picking:
-                copy_vals = self._first_picking_copy_vals(key, lines)
-                picking = first_picking.copy(copy_vals)
-            po_lines = self.env["purchase.order.line"]
-            for line in list(lines):
-                po_lines += line
-            moves += super(PurchaseOrderLine, po_lines)._create_stock_moves(picking)
+            po_lines = self.browse().concat(*lines)
+            if (
+                not picking.move_ids
+                or picking.move_ids == po_lines
+                or picking.filtered_domain(
+                    picking._purchase_split_date_assign_domain(key, tz)
+                )
+            ):
+                # when the picking is empty or contains all the lines or is
+                # valid for the key
+                moves += super(PurchaseOrderLine, po_lines)._create_stock_moves(picking)
+            else:
+                moves_to_assign = super(
+                    PurchaseOrderLine, po_lines
+                )._create_stock_moves(picking.browse())
+                moves_to_assign.with_context(
+                    purchase_delivery_split_date=True
+                )._assign_picking()
+                moves_to_assign._action_confirm()
+                moves += moves_to_assign
         return moves
-
-    def write(self, values):
-        res = super().write(values)
-        if "date_planned" in values:
-            self._check_split_moves_by_date()
-        return res
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        lines = super().create(vals_list)
-        lines.filtered(
-            lambda line: lines.order_id.state == "purchase"
-        )._check_split_moves_by_date()
-        return lines
 
     def _compute_price_unit_and_date_planned_and_name(self):
         """
@@ -109,36 +97,3 @@ class PurchaseOrderLine(models.Model):
             ):
                 line.date_planned = date_planned_by_record[line.id]
         return res
-
-    def _get_picking_domain_split_by_date(self):
-        """
-        Don't split pickings that are done or cancel or that have been
-        printed.
-        """
-        return [("state", "not in", ("done", "cancel")), ("printed", "=", False)]
-
-    def _check_split_moves_by_date(self):
-        for group_date, lines in self.partition(
-            self._get_split_move_by_date_group()
-        ).items():
-            for picking, moves in lines.move_ids.partition("picking_id").items():
-                if not picking.filtered_domain(
-                    self._get_picking_domain_split_by_date()
-                ):
-                    continue
-                moves._do_unreserve()
-                moves.update(
-                    {
-                        "date": group_date,
-                        "date_deadline": group_date,
-                        "picking_id": False,
-                    }
-                )
-                moves.with_context(purchase_delivery_split_date=True)._assign_picking()
-                for move in moves:
-                    if not move.picking_id.partner_id:
-                        move.picking_id.write({"partner_id": picking.partner_id.id})
-                moves._action_assign()
-                picking.filtered(lambda picking: not picking.move_ids).write(
-                    {"state": "cancel"}
-                )

--- a/purchase_delivery_split_date/models/stock_move.py
+++ b/purchase_delivery_split_date/models/stock_move.py
@@ -1,15 +1,70 @@
-from odoo import models
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import pytz
+
+from odoo import fields, models
 from odoo.osv import expression
+from odoo.tools import groupby
 
 
 class StockMove(models.Model):
 
     _inherit = "stock.move"
 
+    def _purchase_split_date_get_group_keys(self):
+        tz = self.picking_type_id.warehouse_id.partner_id.tz or self.env.user.tz
+        wh_tz = pytz.timezone(tz or "UTC")
+        date_planned_tz = self.date_deadline.astimezone(pytz.utc).astimezone(wh_tz)
+        date = date_planned_tz.date()
+        # Split date value to obtain only the attributes year, month and day
+        key = ({"date_planned": fields.Date.to_string(date)},)
+        return key
+
     def _search_picking_for_assignation_domain(self):
         domain = super()._search_picking_for_assignation_domain()
         if self.env.context.get("purchase_delivery_split_date"):
+            key = self._purchase_split_date_get_group_keys()
+            tz = self.picking_type_id.warehouse_id.partner_id.tz or self.env.user.tz
             domain = expression.AND(
-                [domain, [("scheduled_date", "=", self.date_deadline)]]
+                [domain, self.picking_id._purchase_split_date_assign_domain(key, tz)]
             )
         return domain
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "date_deadline" in vals:
+            self._purchase_split_by_date(vals["date_deadline"])
+        return res
+
+    def _purchase_split_by_date(self, new_deadline):
+        po_moves = self.filtered(
+            lambda m: m.purchase_line_id and m.state not in ("done", "cancel")
+        )
+        if not po_moves:
+            return
+        po_moves.date = new_deadline
+        for picking, moves_list in groupby(po_moves, lambda m: m.picking_id):
+            if picking.printed:
+                # Do not split by date anymore
+                continue
+            # todo: if all moves on the same date
+            moves = self.browse().concat(*moves_list)
+            # the picking is not valid anymore
+            reserved_moves = moves.filtered(
+                lambda m: m.state in ("partially_available", "assigned")
+            )
+            reserved_moves._do_unreserve()
+            moves.picking_id = False
+            if picking.move_ids:
+                # recompute the picking dates as some moves have been
+                # removed
+                picking._compute_scheduled_date()
+                picking._compute_date_deadline()
+            else:
+                picking.state = "cancel"
+            moves.with_context(purchase_delivery_split_date=True)._assign_picking()
+            for new_picking in moves.picking_id:
+                if not new_picking.partner_id and picking.partner_id:
+                    new_picking.partner_id = picking.partner_id
+            reserved_moves._action_assign()

--- a/purchase_delivery_split_date/models/stock_picking.py
+++ b/purchase_delivery_split_date/models/stock_picking.py
@@ -1,19 +1,26 @@
 # Copyright 2014-2016 Numérigraphe SARL
 # Copyright 2017 ForgeFlow, S.L.
+# Copyright 2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import models
+
+import pytz
+
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
-    def _update_picking_from_group_key(self, key):
-        """The picking is updated with data from the grouping key.
-        This method is designed for extensibility, so that other modules
-        can store more data based on new keys."""
-        for rec in self:
-            for key_element in key:
-                if "date_planned" in key_element.keys():
-                    rec.date = key_element["date_planned"]
-        return False
+    @api.model
+    def _purchase_split_date_assign_domain(self, key, tz):
+        date = key[0].get("date_planned")
+        wh_tz = pytz.timezone(tz or "UTC")
+        # The date is in local time
+        dt_start_tz = wh_tz.localize(fields.Datetime.to_datetime(date))
+        dt_start = dt_start_tz.astimezone(pytz.utc).replace(tzinfo=None)
+        dt_end = fields.Datetime.add(dt_start, days=1)
+        return [
+            ("scheduled_date", ">=", fields.Datetime.to_string(dt_start)),
+            ("scheduled_date", "<", fields.Datetime.to_string(dt_end)),
+        ]

--- a/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
+++ b/purchase_delivery_split_date/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Mallory Marcot <contact@mallory-marcot.com>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/purchase_delivery_split_date/tests/test_purchase_delivery.py
+++ b/purchase_delivery_split_date/tests/test_purchase_delivery.py
@@ -191,6 +191,16 @@ class TestDeliverySingle(TransactionCase):
         self.assertEqual(len(moves.mapped("picking_id")), 1)
         self.assertEqual(len(pickings.filtered(lambda r: r.state == "cancel")), 1)
 
+    def test_purchase_line_time_change_nosplit_picking(self):
+        self.po.button_confirm()
+        line1 = self.po.order_line[0]
+        line1.write({"date_planned": Datetime.add(line1.date_planned, minutes=1)})
+        self.assertEqual(
+            len(self.po.picking_ids),
+            1,
+            "There must be 1 picking when I change the time",
+        )
+
     def test_purchase_line_date_change_split_picking(self):
         self.po.button_confirm()
         line1 = self.po.order_line[0]
@@ -198,6 +208,7 @@ class TestDeliverySingle(TransactionCase):
         move1 = self.env["stock.move"].search([("purchase_line_id", "=", line1.id)])
         move2 = self.env["stock.move"].search([("purchase_line_id", "=", line2.id)])
 
+        # Check when date is put later
         line1.write({"date_planned": self.date_later})
         self.assertEqual(
             len(self.po.picking_ids),
@@ -214,9 +225,36 @@ class TestDeliverySingle(TransactionCase):
             "If I change the other line to the same date as the first, "
             "both moves must be in the same picking",
         )
+        self.assertEqual(
+            len(self.po.picking_ids),
+            2,
+            "There must be 2 picking as line3 is still sooner",
+        )
         # Check move is well assigned
         self.assertEqual("assigned", move2.picking_id.state)
         self.assertTrue(move2.move_line_ids)
+        # Now check when date is put sooner
+        line1.write({"date_planned": self.date_sooner})
+        self.assertEqual(
+            len(self.po.picking_ids),
+            2,
+            "There must be 2 pickings when I change the date",
+        )
+        self.assertEqual(move1.date_deadline.strftime("%Y-%m-%d"), self.date_sooner)
+        self.assertEqual(move2.date_deadline.strftime("%Y-%m-%d"), self.date_later)
+        self.assertNotEqual(move1.picking_id, move2.picking_id)
+        line2.write({"date_planned": self.date_sooner})
+        self.assertEqual(
+            move1.picking_id,
+            move2.picking_id,
+            "If I change the other line to the same date as the first, "
+            "both moves must be in the same picking",
+        )
+        self.assertEqual(
+            len(self.po.picking_ids),
+            1,
+            "There must be 1 picking",
+        )
 
     def test_purchase_line_created_afer_confirm(self):
         """Check new line created when order is confirmed.
@@ -271,9 +309,9 @@ class TestDeliverySingle(TransactionCase):
         self.assertEqual(len(self.po.picking_ids), 1)
 
         self.env.user.tz = "Etc/UTC"
-        line1.write({"date_planned": "2021-05-05 03:00:00"})
-        self.assertEqual(len(self.po.picking_ids), 1)
         # No time difference so will be another day (2 pickings)
+        line1.write({"date_planned": "2021-05-05 03:00:00"})
+        self.assertEqual(len(self.po.picking_ids), 2)
         line2.write({"date_planned": "2021-05-04 23:00:00"})
         self.assertEqual(len(self.po.picking_ids), 2)
 


### PR DESCRIPTION
Fix po line addition. Reduce the amount of canceled picking. Ensure there one picking per date even when different time. Ensure po line planned time is kept on move deadline. Make proper date comparison timezone aware.
Changing the deadline on a move linked to a PO will also trigger the split by date.
Only rely on picking assignation domain for checking if the picking is still right.

cc @rousseldenis 